### PR TITLE
add IPV6_TRANSPARENT for tproxy

### DIFF
--- a/src/socket.rs
+++ b/src/socket.rs
@@ -1736,6 +1736,46 @@ impl Socket {
         }
     }
 
+    /// Get the value of the `IPV6_TRANSPARENT` option on this socket.
+    ///
+    /// For more information about this option, see [`set_ip_transparent_v6`].
+    ///
+    /// [`set_ip_transparent_v6`]: Socket::set_ip_transparent_v6
+    #[cfg(all(feature = "all", target_os = "linux"))]
+    pub fn ip_transparent_v6(&self) -> io::Result<bool> {
+        unsafe {
+            getsockopt::<c_int>(self.as_raw(), sys::IPPROTO_IPV6, libc::IPV6_TRANSPARENT)
+                .map(|transparent| transparent != 0)
+        }
+    }
+
+    /// Set the value of the `IPV6_TRANSPARENT` option on this socket.
+    ///
+    /// Setting this boolean option enables transparent proxying
+    /// on this socket.  This socket option allows the calling
+    /// application to bind to a nonlocal IP address and operate
+    /// both as a client and a server with the foreign address as
+    /// the local endpoint.  NOTE: this requires that routing be
+    /// set up in a way that packets going to the foreign address
+    /// are routed through the TProxy box (i.e., the system
+    /// hosting the application that employs the IPV6_TRANSPARENT
+    /// socket option).  Enabling this socket option requires
+    /// superuser privileges (the `CAP_NET_ADMIN` capability).
+    ///
+    /// TProxy redirection with the iptables TPROXY target also
+    /// requires that this option be set on the redirected socket.
+    #[cfg(all(feature = "all", target_os = "linux"))]
+    pub fn set_ip_transparent_v6(&self, transparent: bool) -> io::Result<()> {
+        unsafe {
+            setsockopt(
+                self.as_raw(),
+                sys::IPPROTO_IPV6,
+                libc::IPV6_TRANSPARENT,
+                transparent as c_int,
+            )
+        }
+    }
+
     /// Join a multicast group using `IPV6_ADD_MEMBERSHIP` option on this socket.
     ///
     /// Some OSs use `IPV6_JOIN_GROUP` for this option.

--- a/tests/socket.rs
+++ b/tests/socket.rs
@@ -1505,6 +1505,13 @@ test!(IPv6 tclass_v6, set_tclass_v6(96));
 )))]
 test!(IPv6 recv_tclass_v6, set_recv_tclass_v6(true));
 
+#[cfg(all(feature = "all", target_os = "linux"))]
+test!(
+    #[ignore = "setting `IPV6_TRANSPARENT` requires the `CAP_NET_ADMIN` capability (works when running as root)"]
+    ip_transparent_v6,
+    set_ip_transparent_v6(true)
+);
+
 #[cfg(all(
     feature = "all",
     not(any(


### PR DESCRIPTION
Add the IPv6 transparent socket option for TPROXY on linux