### PR TITLE
fix: broken windows CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -43,6 +43,9 @@ jobs:
       with:
         toolchain: ${{ matrix.rust }}
     - uses: taiki-e/install-action@cargo-hack
+    - name: Pin windows-sys for MSRV compatibility
+      if: matrix.os == 'windows-latest' && matrix.rust == '1.70.0'
+      run: cargo update -p windows-sys --precise 0.60.2
     - name: Run tests
       run: cargo hack test --feature-powerset && cargo hack test --feature-powerset --release
   Rustfmt:


### PR DESCRIPTION
windows CI is failing  https://github.com/rust-lang/socket2/issues/640

```
Run cargo hack test --feature-powerset && cargo hack test --feature-powerset --release
running `cargo test --no-default-features` on socket2 (1/2)
   Downloading crates ...
    Downloaded windows-link v0.2.1
    Downloaded windows-sys v0.61.2
  error: package `windows-sys v0.61.2` cannot be built because it requires rustc 1.71 or newer, while the currently active rustc version is 1.70.0
  Either upgrade to rustc 1.71 or newer, or use
  cargo update -p windows-sys@0.61.2 --precise ver
  where `ver` is the latest version of `windows-sys` supporting rustc 1.70.0
error: process didn't exit successfully: `\\?\C:\Users\runneradmin\.rustup\toolchains\1.70.0-x86_64-pc-windows-msvc\bin\cargo.exe test --manifest-path Cargo.toml --no-default-features` (exit code: 101)
Error: Process completed with exit code 1.
```